### PR TITLE
表示崩れを事前修正するMarkdown拡張を追加

### DIFF
--- a/commit.py
+++ b/commit.py
@@ -39,18 +39,17 @@ class CommitExtension(Extension):
         pre = CommitPreprocessor(md)
 
         md.registerExtension(self)
-        md.preprocessors.add('commit', pre, ">normalize_whitespace")
+        #md.preprocessors.add('commit', pre, ">normalize_whitespace")
+        md.preprocessors.register(pre, 'commit', 25)
 
 
 class CommitPreprocessor(Preprocessor):
 
     def __init__(self, md):
         Preprocessor.__init__(self, md)
-        self._markdown = md
 
     def run(self, lines):
         new_lines = []
-        self._markdown._meta_result = {}
 
         for line in lines:
             new_line = replace_commit_line(line)

--- a/commit.py
+++ b/commit.py
@@ -39,7 +39,6 @@ class CommitExtension(Extension):
         pre = CommitPreprocessor(md)
 
         md.registerExtension(self)
-        #md.preprocessors.add('commit', pre, ">normalize_whitespace")
         md.preprocessors.register(pre, 'commit', 25)
 
 

--- a/fix_display_error.py
+++ b/fix_display_error.py
@@ -15,6 +15,11 @@ from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
 def is_item_line(line: str) -> bool:
+    if line.startswith("    "):
+        return True
+    if line.startswith("\t"):
+        return True
+
     stripped_line = line.strip()
     m = re.match(r'^([0-9]+\.\s)', stripped_line)
     if m:

--- a/fix_display_error.py
+++ b/fix_display_error.py
@@ -6,7 +6,6 @@
 Markdownライブラリの以下の制限を回避：
 
 - 箇条書きの前に空行が必要な制限を回避して、自動で空行を挟む
-- コードブロックのあとにコード修飾以外を書く際は空行が必要になる制限を回避して、自動で空行を挟む
 """
 
 import re
@@ -26,29 +25,13 @@ def is_item_line(line: str) -> bool:
         return True
     return False
 
-def is_qualify_or_meta(line: str) -> bool:
-    if not is_item_line(line):
-        return False
-    if "[meta" in line:
-        return True
-    if "[mathjax enable]" in line:
-        return True
-    if "[link" in line:
-        return True
-    if "[color" in line:
-        return True
-    if "[italic]" in line:
-        return True
-    return False
-
 class FixDisplayErrorExtension(Extension):
 
     def extendMarkdown(self, md, md_globals):
         pre = FixDisplayErrorPreprocessor(md)
 
         md.registerExtension(self)
-        #md.preprocessors.add('fix_display_error', pre, ">qualified_fenced_code")
-        md.preprocessors.register(pre, 'fix_display_error', 29)
+        md.preprocessors.register(pre, 'fix_display_error', 28)
 
 
 class FixDisplayErrorPreprocessor(Preprocessor):
@@ -62,7 +45,6 @@ class FixDisplayErrorPreprocessor(Preprocessor):
         in_outer_code_block: bool = False
         in_code_block: bool = False
         prev_line: str | None = None
-        is_prev_code_block = False
         for line in lines:
             is_outer_code_block = line.strip().startswith("````")
             if is_outer_code_block:
@@ -81,17 +63,13 @@ class FixDisplayErrorPreprocessor(Preprocessor):
                         new_lines.append(line)
                         continue
 
-            if is_prev_code_block and len(line) > 0 and not is_item_line(line) and not is_qualify_or_meta(line):
-                is_prev_code_block = False
-                new_lines.append("")
-
             if in_code_block:
                 prev_line = line
                 new_lines.append(line)
                 continue
 
-            if prev_line != None:
-                if not is_item_line(prev_line) and is_item_line(line) and not is_qualify_or_meta(line):
+            if prev_line != None and len(prev_line) > 0:
+                if not is_item_line(prev_line) and is_item_line(line):
                     new_lines.append("")
 
             prev_line = line

--- a/fix_display_error.py
+++ b/fix_display_error.py
@@ -15,11 +15,6 @@ from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
 def is_item_line(line: str) -> bool:
-    if line.startswith("    "):
-        return True
-    if line.startswith("\t"):
-        return True
-
     stripped_line = line.strip()
     m = re.match(r'^([0-9]+\.\s)', stripped_line)
     if m:
@@ -48,10 +43,20 @@ class FixDisplayErrorPreprocessor(Preprocessor):
         new_lines = []
 
         prev_line: str | None = None
+        in_item: bool = False
         for line in lines:
-            if prev_line != None and len(prev_line) > 0:
-                if not is_item_line(prev_line) and is_item_line(line):
-                    new_lines.append("")
+            if prev_line == None:
+                prev_line = line
+                new_lines.append(line)
+                continue
+
+            if not is_item_line(prev_line) and not in_item and is_item_line(line):
+                new_lines.append("")
+
+            if not in_item and is_item_line(line):
+                in_item = True
+            if in_item and len(line) == 0:
+                in_item = False
 
             prev_line = line
             new_lines.append(line)

--- a/fix_display_error.py
+++ b/fix_display_error.py
@@ -28,7 +28,8 @@ class FixDisplayErrorExtension(Extension):
         pre = FixDisplayErrorPreprocessor(md)
 
         md.registerExtension(self)
-        md.preprocessors.add('fix_display_error', pre, ">normalize_whitespace")
+        #md.preprocessors.add('fix_display_error', pre, ">qualified_fenced_code")
+        md.preprocessors.register(pre, 'fix_display_error', 29)
 
 
 class FixDisplayErrorPreprocessor(Preprocessor):

--- a/fix_display_error.py
+++ b/fix_display_error.py
@@ -42,32 +42,8 @@ class FixDisplayErrorPreprocessor(Preprocessor):
     def run(self, lines):
         new_lines = []
 
-        in_outer_code_block: bool = False
-        in_code_block: bool = False
         prev_line: str | None = None
         for line in lines:
-            is_outer_code_block = line.strip().startswith("````")
-            if is_outer_code_block:
-                in_outer_code_block = not in_outer_code_block
-                prev_line = line
-                new_lines.append(line)
-                continue
-
-            if not in_outer_code_block:
-                is_code_block = line.strip().startswith("```")
-                if is_code_block:
-                    in_code_block = not in_code_block
-                    if not in_code_block:
-                        is_prev_code_block = True
-                        prev_line = line
-                        new_lines.append(line)
-                        continue
-
-            if in_code_block:
-                prev_line = line
-                new_lines.append(line)
-                continue
-
             if prev_line != None and len(prev_line) > 0:
                 if not is_item_line(prev_line) and is_item_line(line):
                     new_lines.append("")

--- a/fix_display_error.py
+++ b/fix_display_error.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+"""
+表示崩れを事前修正
+=========================================
+
+Markdownライブラリの箇条書きの前に空行が必要な制限を回避
+"""
+
+import re
+import datetime
+
+from markdown.extensions import Extension
+from markdown.preprocessors import Preprocessor
+
+def is_item_line(line: str) -> bool:
+    m = re.match(r'^([0-9]+\.\s)', line)
+    if m:
+        return True
+
+    m = re.match(r'^([+-]\s)', line)
+    if m:
+        return True
+    return False
+
+class FixDisplayErrorExtension(Extension):
+
+    def extendMarkdown(self, md, md_globals):
+        pre = FixDisplayErrorPreprocessor(md)
+
+        md.registerExtension(self)
+        md.preprocessors.add('fix_display_error', pre, ">normalize_whitespace")
+
+
+class FixDisplayErrorPreprocessor(Preprocessor):
+
+    def __init__(self, md):
+        Preprocessor.__init__(self, md)
+        self._markdown = md
+
+    def run(self, lines):
+        new_lines = []
+        self._markdown._meta_result = {}
+
+        in_code_block: bool = False
+        prev_line: str | None = None
+        for line in lines:
+            is_code_block = line.strip().startswith("```")
+            if is_code_block:
+                in_code_block = not in_code_block
+
+            if in_code_block:
+                new_lines.append(line)
+                continue
+
+            if prev_line != None:
+                if not is_item_line(prev_line) and is_item_line(line):
+                    new_lines.append("")
+
+            prev_line = line
+            new_lines.append(line)
+
+        return new_lines
+
+
+def makeExtension(**kwargs):
+    return FixDisplayErrorExtension(**kwargs)

--- a/fix_display_error.py
+++ b/fix_display_error.py
@@ -25,6 +25,13 @@ def is_item_line(line: str) -> bool:
         return True
     return False
 
+def is_item_end_line(line: str) -> bool:
+    if len(line) == 0:
+        return True
+    if re.match(r'^#+ ', line):
+        return True
+    return False
+
 class FixDisplayErrorExtension(Extension):
 
     def extendMarkdown(self, md, md_globals):
@@ -55,7 +62,7 @@ class FixDisplayErrorPreprocessor(Preprocessor):
 
             if not in_item and is_item_line(line):
                 in_item = True
-            if in_item and len(line) == 0:
+            if in_item and is_item_end_line(line):
                 in_item = False
 
             prev_line = line

--- a/fix_display_error.py
+++ b/fix_display_error.py
@@ -3,7 +3,10 @@
 表示崩れを事前修正
 =========================================
 
-Markdownライブラリの箇条書きの前に空行が必要な制限を回避
+Markdownライブラリの以下の制限を回避：
+
+- 箇条書きの前に空行が必要な制限を回避して、自動で空行を挟む
+- コードブロックのあとにコード修飾以外を書く際は空行が必要になる制限を回避して、自動で空行を挟む
 """
 
 import re
@@ -13,12 +16,28 @@ from markdown.extensions import Extension
 from markdown.preprocessors import Preprocessor
 
 def is_item_line(line: str) -> bool:
-    m = re.match(r'^([0-9]+\.\s)', line)
+    stripped_line = line.strip()
+    m = re.match(r'^([0-9]+\.\s)', stripped_line)
     if m:
         return True
 
-    m = re.match(r'^([+-]\s)', line)
+    m = re.match(r'^([*+-]\s)', stripped_line)
     if m:
+        return True
+    return False
+
+def is_qualify_or_meta(line: str) -> bool:
+    if not is_item_line(line):
+        return False
+    if "[meta" in line:
+        return True
+    if "[mathjax enable]" in line:
+        return True
+    if "[link" in line:
+        return True
+    if "[color" in line:
+        return True
+    if "[italic]" in line:
         return True
     return False
 
@@ -36,25 +55,43 @@ class FixDisplayErrorPreprocessor(Preprocessor):
 
     def __init__(self, md):
         Preprocessor.__init__(self, md)
-        self._markdown = md
 
     def run(self, lines):
         new_lines = []
-        self._markdown._meta_result = {}
 
+        in_outer_code_block: bool = False
         in_code_block: bool = False
         prev_line: str | None = None
+        is_prev_code_block = False
         for line in lines:
-            is_code_block = line.strip().startswith("```")
-            if is_code_block:
-                in_code_block = not in_code_block
+            is_outer_code_block = line.strip().startswith("````")
+            if is_outer_code_block:
+                in_outer_code_block = not in_outer_code_block
+                prev_line = line
+                new_lines.append(line)
+                continue
+
+            if not in_outer_code_block:
+                is_code_block = line.strip().startswith("```")
+                if is_code_block:
+                    in_code_block = not in_code_block
+                    if not in_code_block:
+                        is_prev_code_block = True
+                        prev_line = line
+                        new_lines.append(line)
+                        continue
+
+            if is_prev_code_block and len(line) > 0 and not is_item_line(line) and not is_qualify_or_meta(line):
+                is_prev_code_block = False
+                new_lines.append("")
 
             if in_code_block:
+                prev_line = line
                 new_lines.append(line)
                 continue
 
             if prev_line != None:
-                if not is_item_line(prev_line) and is_item_line(line):
+                if not is_item_line(prev_line) and is_item_line(line) and not is_qualify_or_meta(line):
                     new_lines.append("")
 
             prev_line = line

--- a/footer.py
+++ b/footer.py
@@ -20,7 +20,8 @@ class FooterExtension(markdown.Extension):
         footer = FooterTreeprocessor()
         footer.config = self.getConfigs()
         md.registerExtension(self)
-        md.treeprocessors.add('footer', footer, '_begin')
+        #md.treeprocessors.add('footer', footer, '_begin')
+        md.treeprocessors.register(footer, 'footer', 50) # top priority (begin)
 
 
 class FooterTreeprocessor(markdown.treeprocessors.Treeprocessor):

--- a/mark.py
+++ b/mark.py
@@ -31,18 +31,17 @@ class MarkExtension(Extension):
         markpre = MarkPreprocessor(md)
 
         md.registerExtension(self)
-        md.preprocessors.add('mark', markpre, ">normalize_whitespace")
+        #md.preprocessors.add('mark', markpre, ">normalize_whitespace")
+        md.preprocessors.register(markpre, 'mark', 25)
 
 
 class MarkPreprocessor(Preprocessor):
 
     def __init__(self, md):
         Preprocessor.__init__(self, md)
-        self._markdown = md
 
     def run(self, lines):
         new_lines = []
-        self._markdown._meta_result = {}
         pattern = re.compile("|".join(map(re.escape, MARK_DICT.keys())))
 
         for line in lines:

--- a/mark.py
+++ b/mark.py
@@ -31,7 +31,6 @@ class MarkExtension(Extension):
         markpre = MarkPreprocessor(md)
 
         md.registerExtension(self)
-        #md.preprocessors.add('mark', markpre, ">normalize_whitespace")
         md.preprocessors.register(markpre, 'mark', 25)
 
 

--- a/mathjax.py
+++ b/mathjax.py
@@ -28,7 +28,8 @@ class MathJaxExtension(Extension):
         mathjaxpre = MathJaxPreprocessor(md)
 
         md.registerExtension(self)
-        md.preprocessors.add('mathjax', mathjaxpre, ">normalize_whitespace")
+        #md.preprocessors.add('mathjax', mathjaxpre, ">normalize_whitespace")
+        md.preprocessors.register(mathjaxpre, 'mathjax', 25)
 
 
 class MathJaxPreprocessor(Preprocessor):

--- a/mathjax.py
+++ b/mathjax.py
@@ -28,7 +28,6 @@ class MathJaxExtension(Extension):
         mathjaxpre = MathJaxPreprocessor(md)
 
         md.registerExtension(self)
-        #md.preprocessors.add('mathjax', mathjaxpre, ">normalize_whitespace")
         md.preprocessors.register(mathjaxpre, 'mathjax', 25)
 
 

--- a/meta.py
+++ b/meta.py
@@ -40,8 +40,10 @@ class MetaExtension(Extension):
         metapost = MetaPostprocessor(md)
 
         md.registerExtension(self)
-        md.preprocessors.add('meta', metapre, ">normalize_whitespace")
-        md.postprocessors.add('meta', metapost, '_end')
+        #md.preprocessors.add('meta', metapre, ">normalize_whitespace")
+        #md.postprocessors.add('meta', metapost, '_end')
+        md.preprocessors.register(metapre, 'meta', 25)
+        md.postprocessors.register(metapost, 'meta', 0) # bottom priority (end)
 
 
 class MetaPreprocessor(Preprocessor):

--- a/meta.py
+++ b/meta.py
@@ -40,8 +40,6 @@ class MetaExtension(Extension):
         metapost = MetaPostprocessor(md)
 
         md.registerExtension(self)
-        #md.preprocessors.add('meta', metapre, ">normalize_whitespace")
-        #md.postprocessors.add('meta', metapost, '_end')
         md.preprocessors.register(metapre, 'meta', 25)
         md.postprocessors.register(metapost, 'meta', 0) # bottom priority (end)
 

--- a/qualified_fenced_code.py
+++ b/qualified_fenced_code.py
@@ -55,7 +55,8 @@ class QualifiedFencedCodeExtension(Extension):
         fenced_block = QualifiedFencedBlockPreprocessor(md, self.global_qualify_list)
         md.registerExtension(self)
 
-        md.preprocessors.add('qualified_fenced_code', fenced_block, ">normalize_whitespace")
+        #md.preprocessors.add('qualified_fenced_code', fenced_block, ">normalize_whitespace")
+        md.preprocessors.register(fenced_block, 'qualified_fenced_code', 28)
 
 
 def _make_random_string():

--- a/qualified_fenced_code.py
+++ b/qualified_fenced_code.py
@@ -65,8 +65,7 @@ class QualifiedFencedCodeExtension(Extension):
         fenced_block = QualifiedFencedBlockPreprocessor(md, self.global_qualify_list)
         md.registerExtension(self)
 
-        #md.preprocessors.add('qualified_fenced_code', fenced_block, ">normalize_whitespace")
-        md.preprocessors.register(fenced_block, 'qualified_fenced_code', 28)
+        md.preprocessors.register(fenced_block, 'qualified_fenced_code', 29)
 
 
 def _make_random_string():

--- a/sponsor.py
+++ b/sponsor.py
@@ -80,18 +80,17 @@ class SponsorExtension(Extension):
         pre = SponsorPreprocessor(md)
 
         md.registerExtension(self)
-        md.preprocessors.add('sponsor', pre, ">normalize_whitespace")
+        #md.preprocessors.add('sponsor', pre, ">normalize_whitespace")
+        md.preprocessors.register(pre, 'sponsor', 25)
 
 
 class SponsorPreprocessor(Preprocessor):
 
     def __init__(self, md):
         Preprocessor.__init__(self, md)
-        self._markdown = md
 
     def run(self, lines):
         new_lines = []
-        self._markdown._meta_result = {}
 
         jst = datetime.timezone(datetime.timedelta(hours=+9), 'JST')
         now = datetime.datetime.now(jst)

--- a/sponsor.py
+++ b/sponsor.py
@@ -80,7 +80,6 @@ class SponsorExtension(Extension):
         pre = SponsorPreprocessor(md)
 
         md.registerExtension(self)
-        #md.preprocessors.add('sponsor', pre, ">normalize_whitespace")
         md.preprocessors.register(pre, 'sponsor', 25)
 
 


### PR DESCRIPTION
- https://github.com/cpprefjp/site/issues/1362

影響範囲が大きいので、一旦Pull Requestにします。
どなたかレビューしてもらえると助かりますが、とくにご意見なければ一週間ほどでマージします。

site_generator側は、この拡張を使うよう1行追加するだけです。

```patch
diff --git forkSrcPrefix/run.py forkDstPrefix/run.py
index 3a783c5504a7856e048800b357fa4698f0f7e9b4..25ac1f1118bf307dcd187a5435e66e76557f793f 100755
--- forkSrcPrefix/run.py
+++ forkDstPrefix/run.py
@@ -102,6 +102,7 @@ def md_to_html(md_data, path, hrefs=None, global_qualify_list=None, global_defin
         'markdown_to_html.mark',
         'markdown_to_html.sponsor',
         'markdown_to_html.commit',
+        'markdown_to_html.fix_display_error',
         ],
         extension_configs=extension_configs)
     md._html_attribute_hrefs = hrefs
```