### PR TITLE
コードブロック後の修飾の抽出を厳密化

### DIFF
--- a/qualified_fenced_code.py
+++ b/qualified_fenced_code.py
@@ -41,7 +41,17 @@ from markdown.preprocessors import Preprocessor
 CODE_WRAP = '<pre><code%s>%s</code></pre>'
 LANG_TAG = ' class="%s"'
 
-QUALIFIED_FENCED_BLOCK_RE = re.compile(r'(?P<fence>`{3,})[ ]*(?P<lang>[a-zA-Z0-9_+-]*)(?P<lang_meta>.*?)\n(?P<code>.*?)(?<=\n)(?P<indent>[ \t]*)(?P=fence)[ ]*\n(?:(?=\n)|(?P<qualifies>.*?\n(?=\s*\n)))', re.MULTILINE | re.DOTALL)
+# qualifier の各行は以下の形式を持つことを要求する。箇条書きまたは番号リストの
+# 項目であり、[meta ...], [mathjax enable ...], [link ...], [color ...],
+# [italic] の何れかの修飾子が含まれていること。インデントレベルは少なくとも ```
+# と同じであること。
+QUALIFIER_LINE_RE_STRING = r'(?P=indent)\s*(?:[-*+]|[0-9]+\.)\s[^\n]*\[(?:meta|mathjax enable|link|color|italic)\b[^\n]*\][^\n]*\n'
+
+# 以下の正規表現は qualifier 行の連続を規定する。最初の qualifier が、閉じ ```
+# と同じレベルの箇条書きまたは番号リストの項目でなければそこで中断する。
+QUALIFIERS_RE_STRING = r'(?:(?!(?P=indent)(?:[-*+]|[0-9]+\.)\s)|(?P<qualifies>(?:%s)*))' % QUALIFIER_LINE_RE_STRING
+
+QUALIFIED_FENCED_BLOCK_RE = re.compile(r'(?P<fence>`{3,})[ ]*(?P<lang>[a-zA-Z0-9_+-]*)(?P<lang_meta>.*?)\n(?P<code>.*?)(?<=\n)(?P<indent>[ \t]*)(?P=fence)[ ]*\n' + QUALIFIERS_RE_STRING, re.MULTILINE | re.DOTALL)
 QUALIFY_COMMAND_RE = re.compile(r'\[(.*?)\]')
 INDENT_RE = re.compile(r'^[ \t]+', re.MULTILINE)
 

--- a/qualified_fenced_code.py
+++ b/qualified_fenced_code.py
@@ -41,15 +41,15 @@ from markdown.preprocessors import Preprocessor
 CODE_WRAP = '<pre><code%s>%s</code></pre>'
 LANG_TAG = ' class="%s"'
 
-# qualifier の各行は以下の形式を持つことを要求する。箇条書きまたは番号リストの
-# 項目であり、[meta ...], [mathjax enable ...], [link ...], [color ...],
-# [italic] の何れかの修飾子が含まれていること。インデントレベルは少なくとも ```
-# と同じであること。
-QUALIFIER_LINE_RE_STRING = r'(?P=indent)\s*(?:[-*+]|[0-9]+\.)\s[^\n]*\[(?:meta|mathjax enable|link|color|italic)\b[^\n]*\][^\n]*\n'
+# qualifier の各行は以下の形式を持つことを要求する。"*" による箇条書きの項目で
+# あり、[meta ...], [mathjax enable ...], [link ...], [color ...], [italic] の
+# 何れかの修飾子が含まれていること。インデントレベルは少なくとも閉じ ``` と同じ
+# であること。
+QUALIFIER_LINE_RE_STRING = r'(?P=indent)\s*\*\s[^\n]*\[(?:meta|mathjax enable|link|color|italic)\b[^\n]*\][^\n]*\n'
 
 # 以下の正規表現は qualifier 行の連続を規定する。最初の qualifier が、閉じ ```
-# と同じレベルの箇条書きまたは番号リストの項目でなければそこで中断する。
-QUALIFIERS_RE_STRING = r'(?:(?!(?P=indent)(?:[-*+]|[0-9]+\.)\s)|(?P<qualifies>(?:%s)*))' % QUALIFIER_LINE_RE_STRING
+# と同じレベルの "*" による箇条書きの項目でなければそこで中断する。
+QUALIFIERS_RE_STRING = r'(?:(?!(?P=indent)\*\s)|(?P<qualifies>(?:%s)*))' % QUALIFIER_LINE_RE_STRING
 
 QUALIFIED_FENCED_BLOCK_RE = re.compile(r'(?P<fence>`{3,})[ ]*(?P<lang>[a-zA-Z0-9_+-]*)(?P<lang_meta>.*?)\n(?P<code>.*?)(?<=\n)(?P<indent>[ \t]*)(?P=fence)[ ]*\n' + QUALIFIERS_RE_STRING, re.MULTILINE | re.DOTALL)
 QUALIFY_COMMAND_RE = re.compile(r'\[(.*?)\]')


### PR DESCRIPTION
説明は commit message に書いていますのでそちらをご参照下さい。

また、この修正の後は #8 における `qualified_fenced_code.py` と `fix_display_error.py` の優先度 28 & 29 (つまり適用順序) を逆転したら `fix_display_error.py` を単純化できるのではないかと思っています (ちゃんと確かめていないですが…)。