### PR TITLE
C++バージョンのバッジのtypo修正と「C++11を削除」の追加

### DIFF
--- a/meta.py
+++ b/meta.py
@@ -118,6 +118,11 @@ class MetaPostprocessor(postprocessors.Postprocessor):
             'title': 'C++11で非推奨',
             'text': '(C++11で非推奨)',
         },
+        'cpp11removed': {
+            'class_name': 'cpp11removed text-danger',
+            'title': 'C++11で削除',
+            'text': '(C++11で削除)',
+        },
         'cpp14deprecated': {
             'class_name': 'cpp14deprecated text-warning',
             'title': 'C++14で非推奨',

--- a/meta.py
+++ b/meta.py
@@ -125,8 +125,8 @@ class MetaPostprocessor(postprocessors.Postprocessor):
         },
         'cpp14removed': {
             'class_name': 'cpp14removed text-danger',
-            'title': 'C++11で削除',
-            'text': '(C++11で削除)',
+            'title': 'C++14で削除',
+            'text': '(C++14で削除)',
         },
         'cpp17deprecated': {
             'class_name': 'cpp17deprecated text-warning',


### PR DESCRIPTION
- `cpp14removed` の `title` と `text` が「C++11」になっていたので、「C++14」に修正しました。
- `cpp11removed` だけなかったので、追加しました。
    - `std::basic_ios::operator void*()` で使えると思います。